### PR TITLE
Fix writing error in api.

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -18,22 +18,24 @@ def writefile(path, val):
         f.truncate()
         f.write(str(val))
 
+def readfile(path):
+    with open(path, "r") as f:
+        return f.read
+
 def changeval(change_val):
-    with open(value_path, "r+") as f:
-        try:
-            x = int(f.read())
-        except:
-            x = 0
-        y = int(change_val)
-        result = x+y
-
-        if result < 0:
-            result = 0
-
-        f.seek(0)
-        f.write(str(result))
-
-        return result
+    og_val = readfile(value_path)
+    try:
+        x = int(og_val)
+    except:
+        x = 0
+    
+    y = int(change_val)
+    result = x+y
+    if result < 0:
+        result = 0
+    
+    writefile(value_path, result)
+    return result
 
 @app.route("/increase")
 def increase():

--- a/api/main.py
+++ b/api/main.py
@@ -12,6 +12,12 @@ f = open(value_path, "w")
 f.close()
 del(f)
 
+def writefile(path, val):
+    with open(path, "w+") as f:
+        f.seek(0)
+        f.truncate()
+        f.write(str(val))
+
 def changeval(change_val):
     with open(value_path, "r+") as f:
         try:


### PR DESCRIPTION
The api was only overwriting some of the characters in the file, resulting in the number jumping large amounts when the user for example went down from 10, they got 90.